### PR TITLE
docs: fix initial prompts heading typo

### DIFF
--- a/docs/examples/getting_started.md
+++ b/docs/examples/getting_started.md
@@ -45,7 +45,7 @@ task_description = (
 )
 ```
 
-### Creating Inital Prompts
+### Creating Initial Prompts
 
 We've defined some starter prompts below, but feel free to experiment! You might also want to explore create_prompts_from_samples to automatically generate initial prompts based on your data.
 

--- a/docs/examples/llm_as_judge_tutorial.md
+++ b/docs/examples/llm_as_judge_tutorial.md
@@ -76,7 +76,7 @@ Our task: **Given a controversial statement, generate the strongest possible arg
 
 Let's look at what we're working with:
 
-### Creating Inital Prompts
+### Creating Initial Prompts
 
 Here are some starter prompts for generating compelling arguments. Feel free to experiment with your own!
 

--- a/docs/examples/reward_task_tutorial.md
+++ b/docs/examples/reward_task_tutorial.md
@@ -69,7 +69,7 @@ print(df["article"].iloc[0][:170] + "...")
     Investors looking to make an easy buck out of the housing market could be running out of time. Australia's financial regulators are in talks to tighten the process for in...
     
 
-### Creating Inital Prompts
+### Creating Initial Prompts
 
 Here are some starter prompts for JSON extraction. Feel free to experiment with your own approaches!
 


### PR DESCRIPTION
## Problem
Three example docs use the heading "Creating Inital Prompts".

## Solution
Corrected the heading to "Creating Initial Prompts" in the getting started, reward task, and LLM-as-judge tutorials.

## Validation
- `git diff --check`
- `grep -RIn "Creating Initial Prompts\|Creating Inital Prompts" docs/examples`

Confidence: 85/100 (docs/typo).